### PR TITLE
SCP-138 (feature) increase api blacklist limit to 10 million elements

### DIFF
--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -5,7 +5,7 @@ Our API includes a feature that allows you to add items to a blacklist by **emai
 This feature is particularly useful to avoid re-scraping the same results, and counting your credits again for the same data.
 
 <aside class="warning">
-  You can blacklist up to 1 million items.
+  You can blacklist up to 10 million items.
 </aside>
 
 ## List


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - The API documentation has been updated to reflect an increased limit for blacklisted items, raising the maximum from 1 million to 10 million as indicated in the warning section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->