### PR TITLE
[WAITING-FEATURE-MERGE] SCP-23 (feature) api exports management v2

### DIFF
--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -107,8 +107,7 @@ $url = 'https://scrap.io/api/v1/blacklist/my-list-1';
 
 $params = [
   'type' => 'domain',
-  'data' => 'sugarfishsushi.com'
-  # Or 'data' => ['sugarfishsushi.com', 'sugarfishsushi2.com']
+  'data' => ['sugarfishsushi.com']
 ];
 
 $headers = [
@@ -137,8 +136,7 @@ url = 'https://scrap.io/api/v1/blacklist/my-list-1'
 
 params = {
   type: 'domain',
-  data: 'sugarfishsushi.com'
-  # Or data: ['sugarfishsushi.com', 'sugarfishsushi2.com']
+  data: ['sugarfishsushi.com']
 }
 
 headers = {
@@ -158,8 +156,7 @@ url = "https://scrap.io/api/v1/blacklist/my-list-1"
  
 params = {
   "type": "domain",
-  "data": "sugarfishsushi.com"
-  # Or "data": ['sugarfishsushi.com', 'sugarfishsushi2.com']
+  "data": ['sugarfishsushi.com']
 }
  
 headers = {
@@ -175,8 +172,7 @@ json = response.json()
 curl -X POST "https://scrap.io/api/v1/blacklist/my-list-1" \
   -H "Authorization: Bearer xxxxxxxxxx" \
   -d "type=domain" \
-  -d "data=sugarfishsushi.com"
-  # Or -d "data=['sugarfishsushi.com', 'sugarfishsushi2.com']"
+  -d "data=['sugarfishsushi.com']"
 ```
 
 ```javascript
@@ -186,8 +182,7 @@ const url = 'https://scrap.io/api/v1/blacklist/my-list-1'
 
 const params = {
   type: 'domain',
-  data: 'sugarfishsushi.com'
-  // Or data: ['sugarfishsushi.com', 'sugarfishsushi2.com']
+  data: ['sugarfishsushi.com']
 }
 
 const headers = {
@@ -219,7 +214,7 @@ This endpoint allows you to add data to a blacklist (google_id, place_id, domain
 Parameter | type |  Required | Description
 ---------| ------- | ------- | -----------
 type | string | yes | Type of data to add to the blacklist (google_id,place_id,domain,email)
-data | string or array | yes | Data to add to the blacklist. Must be a string "xxx1" or an array of strings ["xxx1", "xxx2"].
+data | array | yes | Data to add to the blacklist. Must be an array of strings ["xxx1", "xxx2"].
 
 ## Delete
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -1,0 +1,194 @@
+# Export
+
+## All
+
+<!--  PHP code -->
+```php
+$url = 'https://scrap.io/api/v1/exports?status=success&order_by=asc';
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+<!--  RUBY code -->
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports?status=success&order_by=asc'
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.get(url, headers: headers)
+
+json = JSON.parse(response.body)
+```
+
+<!--  PYTHON code -->
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports?status=success&order_by=asc"
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.get(url, headers=headers)
+ 
+json = response.json()
+```
+
+<!--  SHELL code -->
+```shell
+curl 'https://scrap.io/api/v1/export?status=success&order_by=asc' \
+    -H "Authorization: Bearer xxxxxxxxxxx"
+```
+
+<!--  JS code -->
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports?status=success&order_by=asc'
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.get(url, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns JSON structured like this:
+
+```json
+{
+    "data": [
+        {
+            "id": 1,
+            "name": "My first export",
+            "country": "FR",
+            "type": "boat-rental-service",
+            "search_params": {
+                "type": "boat-rental-service",
+                "country": "FR",
+                "admin1": "93",
+                "city": "Beaulieu-sur-Mer"
+            },
+            "status": "success",
+            "advanced_fields": [],
+            "exported_lines_limit": null,
+            "exported_columns": [
+                "google_id",
+                "name"
+            ],
+            "prepared_rows_count": 17,
+            "exported_csv_count": 17,
+            "exported_xlsx_count": 17,
+            "is_stopped": false,
+            "has_been_downloaded": true,
+            "credits_used": 0,
+            "export_only_new_email": 0,
+            "export_only_new_place": 0,
+            "scraped_at": "2025-02-16T09:47:39.000000Z",
+            "download_link": "https://scrap.io/app/export/6cedca670e0fd1809aca1b32df32e4c2f10b9ec6ef2f9c5e2a7b80508fdc6a7a/download/csv"
+        },
+        {
+            "id": 2,
+            "name": "Bar karaoké - France - Nouvelle-Aquitaine",
+            "country": "FR",
+            "type": "karaoke-bar",
+            "search_params": {
+                "type": "karaoke-bar",
+                "country": "FR",
+                "admin1": "75"
+            },
+            "status": "success",
+            "advanced_fields": [],
+            "exported_lines_limit": null,
+            "exported_columns": [
+                "google_id",
+                "name"
+            ],
+            "prepared_rows_count": 10,
+            "exported_csv_count": 10,
+            "exported_xlsx_count": 10,
+            "is_stopped": false,
+            "has_been_downloaded": false,
+            "credits_used": 0,
+            "export_only_new_email": 0,
+            "export_only_new_place": 0,
+            "scraped_at": "2025-02-19T07:04:09.000000Z",
+            "download_link": "https://scrap.io/app/export/d22e9717f0185d70848d2f7b75b1ced8a339ee4d4be92697f0cb5c4b6911a5f5/download/csv"
+        },
+    ],
+    "links": {
+        "first": "https://scrap.io/api/v1/exports?page=1",
+        "last": "https://scrap.io/api/v1/exports?page=1",
+        "prev": null,
+        "next": null
+    },
+    "meta": {
+        "current_page": 1,
+        "from": 1,
+        "last_page": 1,
+        "links": [
+            {
+                "url": null,
+                "label": "&laquo; Previous",
+                "active": false
+            },
+            {
+                "url": "https://scrap.io/api/v1/exports?page=1",
+                "label": "1",
+                "active": true
+            },
+            {
+                "url": null,
+                "label": "Next &raquo;",
+                "active": false
+            }
+        ],
+        "path": "https://scrap.io/api/v1/exports",
+        "per_page": 25,
+        "to": 2,
+        "total": 2
+    }
+}
+```
+
+This endpoint allows you to get a paginated list of your exports.
+
+<aside class="warning">
+  We won't return deleted exports.
+</aside>
+
+### HTTP Request
+
+`GET https://scrap.io/api/v1/exports`
+
+### Query parameters
+
+| Parameter | Type          | Default | Required | Description            | Options                                           |
+|-----------|---------------|---------|----------|------------------------|---------------------------------------------------|
+| search    | string        |         | no       | Search in export name  |                                                   |
+| status    | string/array  |         | no       | Status of the export   | in_progress, pending, incomplete, success, error  |
+| orderBy   | string        | desc    | no       | Sort by scraping_date  | asc, desc                                         |
+| page      | integer       | 1       | no       | Get the results for the given page |                                       |

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -370,7 +370,7 @@ params = {
         "name"
     ],
     "gmap_price_range": "$$",
-    "website_has_instagram": true
+    "website_has_instagram": True
 }
  
 headers = {

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -192,3 +192,414 @@ This endpoint allows you to get a paginated list of your exports.
 | status    | string/array  |         | no       | Status of the export   | in_progress, pending, incomplete, success, error  |
 | orderBy   | string        | desc    | no       | Sort by scraping_date  | asc, desc                                         |
 | page      | integer       | 1       | no       | Get the results for the given page |                                       |
+
+
+## Find
+
+<!--  PHP code -->
+```php
+$url = 'https://scrap.io/api/v1/exports/2';
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+<!--  RUBY code -->
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports/2'
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.get(url, headers: headers)
+
+json = JSON.parse(response.body)
+```
+
+<!--  PYTHON code -->
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports/2"
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.get(url, headers=headers)
+ 
+json = response.json()
+```
+
+<!--  SHELL code -->
+```shell
+curl 'https://scrap.io/api/v1/export/2' \
+    -H "Authorization: Bearer xxxxxxxxxxx"
+```
+
+<!--  JS code -->
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports/2'
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.get(url, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns JSON structured like this:
+
+```json
+{
+    "id": 2,
+    "name": "Bar karaoké - France - Nouvelle-Aquitaine",
+    "country": "FR",
+    "type": "karaoke-bar",
+    "search_params": {
+        "type": "karaoke-bar",
+        "country": "FR",
+        "admin1": "75"
+    },
+    "status": "success",
+    "advanced_fields": [],
+    "exported_lines_limit": null,
+    "exported_columns": [
+        "google_id",
+        "name"
+    ],
+    "prepared_rows_count": 10,
+    "exported_csv_count": 10,
+    "exported_xlsx_count": 10,
+    "is_stopped": false,
+    "has_been_downloaded": false,
+    "credits_used": 0,
+    "export_only_new_email": 0,
+    "export_only_new_place": 0,
+    "scraped_at": "2025-02-19T07:04:09.000000Z",
+    "download_link": "https://scrap-io.test/app/export/d22e9717f0185d70848d2f7b75b1ced8a339ee4d4be92697f0cb5c4b6911a5f5/download/csv"
+}
+```
+
+This endpoint allows you to get one of your exports depending on the id.
+
+### HTTP Request
+
+`GET https://scrap.io/api/v1/exports/create`
+
+## Create
+
+```php
+$url = 'https://scrap.io/api/v1/exports/create';
+
+$params = [
+    "name" => "My export name (1)",
+    "country_code" => "FR",
+    "type" => "karaoke-bar",
+    "admin1_code" => "75",
+    "exported_lines_limit" => 4,
+    "exported_columns" => [
+        "google_id", 
+        "name"
+    ],
+    "gmap_price_range" => "$$",
+    "website_has_instagram" => true
+];
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_POST, true);
+curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports/create'
+
+params = {
+    name: "My export name (1)",
+    country_code: "FR",
+    type: "karaoke-bar",
+    admin1_code: "75",
+    exported_lines_limit: 4,
+    exported_columns: [
+        "google_id", 
+        "name"
+    ],
+    gmap_price_range: "$$",
+    website_has_instagram: true
+}
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.post(url, headers: headers, body: params)
+
+json = JSON.parse(response.body)
+```
+
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports/create"
+ 
+params = {
+  "name": "My export name (1)",
+    "country_code": "FR",
+    "type": "karaoke-bar",
+    "admin1_code": "75",
+    "exported_lines_limit": 4,
+    "exported_columns": [
+        "google_id", 
+        "name"
+    ],
+    "gmap_price_range": "$$",
+    "website_has_instagram": true
+}
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.post(url, data=params, headers=headers)
+ 
+json = response.json()
+```
+
+```shell
+curl -X POST "https://scrap.io/api/v1/exports/create" \
+  -H "Authorization: Bearer xxxxxxxxxx" \
+  -d "type=domain" \
+  -d '{
+        "name": "My export name (1)",
+        "country_code": "FR",
+        "type": "karaoke-bar",
+        "admin1_code": "75",
+        "exported_lines_limit": 4,
+        "exported_columns": [
+            "google_id", 
+            "name"
+        ],
+        "gmap_price_range": "$$",
+        "website_has_instagram": true
+    }'
+```
+
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports/create'
+
+const params = {
+    name: "My export name (1)",
+    country_code: "FR",
+    type: "karaoke-bar",
+    admin1_code: "75",
+    exported_lines_limit: 4,
+    exported_columns: [
+        "google_id", 
+        "name"
+    ],
+    gmap_price_range: "$$",
+    website_has_instagram: true
+}
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.post(url, params, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+
+```shell
+curl --location 'https://scrap-io.test/api/v1/exports/create' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: xxxxxxxxxxx' \
+--data '{
+    "name": "My export name (1)",
+    "country_code": "FR",
+    "type": "karaoke-bar",
+    "admin1_code": "75",
+    "exported_lines_limit": 4,
+    "exported_columns": [
+        "google_id", 
+        "name"
+    ],
+    "gmap_price_range": "$$",
+    "website_has_instagram": true
+}'
+```
+
+> The above code returns JSON structured like this:
+
+```json
+{
+    "id": 3,
+    "name": "My export name (1)",
+    "country": "FR",
+    "type": "karaoke-bar",
+    "search_params": {
+        "type": "karaoke-bar",
+        "country": "FR",
+        "admin1": "75"
+    },
+    "status": "pending",
+    "advanced_fields": [],
+    "exported_lines_limit": null,
+    "exported_columns": [
+        "google_id",
+        "name"
+    ],
+    "prepared_rows_count": 10,
+    "exported_csv_count": 10,
+    "exported_xlsx_count": 10,
+    "is_stopped": false,
+    "has_been_downloaded": false,
+    "credits_used": 0,
+    "export_only_new_email": 0,
+    "export_only_new_place": 0,
+    "scraped_at": "2025-02-19T07:04:09.000000Z",
+    "download_link": ""
+}
+```
+
+### HTTP Request
+
+`POST https://scrap.io/api/v1/export/create`
+
+### Body parameters
+
+**Important informations**
+
+- Unless otherwise specified, a non-required field will be null by default (even if not passed in parameters).
+- Filters are ignore if not present or null. For example, if website_has_instagram set to true, we'll return results WITH instagram links, if set to false we'll return results WITHOUT instagram links and if not present at all we'll return results WITH or WITHOUT instagram links.
+
+**Parameters**
+
+| Parameter | Type | Required | Options | Description |
+|---|---|---|---|---|
+| name | string | yes if auto_name not present or false |  | The name of the export. Must be unique, min 3 char and max 255 char. |
+| auto_name | boolean | yes if name not present |  | If set, we'll generate a name for you. |
+| type | string | yes | Id from this [endpoint](https://apidoc.scrap.io/#types) | Type of place. |
+| country_code | string | yes | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Country. |
+| admin1_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 1 division for the country. |
+| admin2_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 2 division for the country. |
+| city_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | City. |
+| exported_lines_limit | integer | no |  | The maximum number of results wanted in the export. |
+| export_only_new_place | boolean | no |  | Export only places not present in previous exports. |
+| export_only_new_email | boolean | no |  | Export only places with email not already present in previous exports. |
+| export_columns | array | yes | See "Export columns" section below | Columns to include in the export file. Require at least one column. |
+| gmap_is_main_type | boolean | no | | Filter by main business type only |
+| gmap_is_closed | boolean | no | | Filter by permanently closed status |
+| gmap_has_website | boolean | no | | Filter by presence of website |
+| gmap_has_phone | boolean | no | | Filter by presence of phone number |
+| gmap_is_claimed | boolean | no | | Filter by claimed business status |
+| gmap_price_range | string | no | $, $$, $$$, $$$$ | Filter by price level |
+| gmap_reviews_rating_gte | float | no | | Filter by rating greater than or equal to value |
+| gmap_reviews_rating_gt | float | no | | Filter by rating greater than value |
+| gmap_reviews_rating_lte | float | no | | Filter by rating less than or equal to value |
+| gmap_reviews_rating_lt | float | no | | Filter by rating less than value |
+| gmap_reviews_count_gte | integer | no | | Filter by number of reviews greater than or equal to value |
+| gmap_reviews_count_gt | integer | no | | Filter by number of reviews greater than value |
+| gmap_reviews_count_lte | integer | no | | Filter by number of reviews less than or equal to value |
+| gmap_reviews_count_lt | integer | no | | Filter by number of reviews less than value |
+| gmap_photos_count_gte | integer | no | | Filter by number of photos greater than or equal to value |
+| gmap_photos_count_gt | integer | no | | Filter by number of photos greater than value |
+| gmap_photos_count_lte | integer | no | | Filter by number of photos less than or equal to value |
+| gmap_photos_count_lt | integer | no | | Filter by number of photos less than value |
+| website_has_emails | boolean | no | | Filter by presence of email addresses on website |
+| website_has_contact_pages | boolean | no | | Filter by presence of contact pages |
+| website_has_facebook | boolean | no | | Filter by presence of Facebook link |
+| website_has_instagram | boolean | no | | Filter by presence of Instagram link |
+| website_has_youtube | boolean | no | | Filter by presence of YouTube link |
+| website_has_twitter | boolean | no | | Filter by presence of Twitter link |
+| website_has_linkedin | boolean | no | | Filter by presence of LinkedIn link |
+| website_has_ad_pixels | boolean | no | | Filter by presence of advertising pixels |
+
+
+**Export columns**
+
+| Parameter | Description |
+|---|---|
+| google_id | Google id |
+| name | Name |
+| descriptions | Descriptions |
+| is_closed | Is closed |
+| main_type | Main type |
+| all_types | Types |
+| website | Website |
+| phone | Phone |
+| timezone | Timezone |
+| location_address | Address |
+| location_coordinates | Coordinates |
+| link | Link |
+| owner | Owner |
+| place_id | Place id |
+| email | Email |
+| facebook_link | Facebook link |
+| youtube_link | Youtube link |
+| twitter_link | Twitter link |
+| instagram_link | Instagram link |
+| linkedin_link | Linkedin link |
+| first_seen_at | Seen for the first time (date) |
+| price_range | Price Range |
+| reviews | Reviews |
+| photos | Photos |
+| occupancy | Occupancy |
+| is_claimed | Is claimed |
+| working_hours | Opening hours |
+| characteristics | Characteristics |
+| website_title | Website name |
+| website_meta | Website meta |
+| website_lang | Website language |
+| all_emails | All emails |
+| contact_pages | Contact pages |
+| all_facebook_links | All facebook links |
+| all_youtube_links | All youtube links |
+| all_twitter_links | All twitter links |
+| all_instagram_links | All instagram links |
+| all_linkedin_links | All linkedin links |
+| website_technologies | Website technologies |
+| website_ad_pixels | Website pixel ad |

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -58,7 +58,7 @@ json = response.json()
 ```shell
 curl --location --request GET 'https://scrap-io.test/api/v1/exports' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx \'
+--header 'Authorization: Bearer xxxxxxxxxxx'
 ```
 
 <!--  JS code -->
@@ -168,7 +168,7 @@ This endpoint allows you to get a paginated list of your exports.
 | search    | string        |         | no       |                                                   | Search in export name  |
 | status    | string/array  |         | no       | in_progress, pending, incomplete, success, error  | Status of the export   |
 | orderBy   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
-| page      | integer       | 1       | no       |                                                   | Get the results for the given page |                                     |
+| page      | integer       | 1       | no       |                                                   | Get the results for the given page |
 
 
 ## Find
@@ -229,7 +229,7 @@ json = response.json()
 ```shell
 curl --location --request GET 'https://scrap-io.test/api/v1/exports/2' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx \'
+--header 'Authorization: Bearer xxxxxxxxxxx'
 ```
 
 <!--  JS code -->
@@ -385,7 +385,7 @@ json = response.json()
 ```shell
 curl --location --request POST 'https://scrap-io.test/api/v1/exports/create' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx \'
+--header 'Authorization: Bearer xxxxxxxxxxx'
 --data '{
     "name": "My export name (1)",
     "country_code": "FR",
@@ -465,7 +465,7 @@ axios.post(url, params, headers)
 
 ### HTTP Request
 
-`POST https://scrap.io/api/v1/export/create`
+`POST https://scrap.io/api/v1/exports/create`
 
 ### Body parameters
 
@@ -623,7 +623,7 @@ json = response.json()
 ```shell
 curl --location --request PATCH 'https://scrap-io.test/api/v1/exports/3' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx \'
+--header 'Authorization: Bearer xxxxxxxxxxx'
 --data '{
     "name": "My new export name",
 }'
@@ -760,11 +760,11 @@ json = response.json()
 ```
 
 ```shell
-curl --location --request DELETE 'https://scrap-io.test/api/v1/export' \
+curl --location --request DELETE 'https://scrap-io.test/api/v1/exports' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx \'
+--header 'Authorization: Bearer xxxxxxxxxxx'
 --data '{
-    "ids": [1, 2]
+    "export_ids": [1, 2]
 }'
 ```
 
@@ -793,7 +793,7 @@ This endpoint allows you to delete one or multiple of your exports.
 
 ### HTTP Request
 
-`DELETE https://scrap.io/api/v1/export`
+`DELETE https://scrap.io/api/v1/exports`
 
 ### Body parameters
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -163,12 +163,12 @@ This endpoint allows you to get a paginated list of your exports.
 
 ### Query parameters
 
-| Parameter | Type          | Default | Required | Options                                           | Description            |
-|-----------|---------------|---------|----------|---------------------------------------------------|------------------------|
-| search    | string        |         | no       |                                                   | Search in export name  |
-| status    | array  |         | no       | preparing-scraping, scraping, preparing-export, exporting-csv, exporting-xlsx, pending, incomplete, success, error  | Status of the export   |
-| order_by   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
-| page      | integer       | 1       | no       |                                                   | Get the results for the given page |
+| Parameter | Type | Default | Required | Options | Description |
+|-----------|------|---------|----------|---------|-------------|
+| search | string | | no | | Search in export name |
+| status | array | | no | preparing-scraping, scraping, preparing-export, exporting-csv, exporting-xlsx, pending, incomplete, success, error | Status of the export |
+| order_by | string | desc | no | asc, desc | Sort by scraping_date  |
+| page | integer | 1 | no | | Get the results for the given page |
 
 
 ## Find
@@ -290,7 +290,7 @@ This endpoint allows you to get one of your exports depending on the id.
 ## Create
 
 ```php
-$url = 'https://scrap.io/api/v1/exports/create';
+$url = 'https://scrap.io/api/v1/exports';
 
 $params = [
     "name" => "My export name (1)",
@@ -328,7 +328,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/exports/create'
+url = 'https://scrap.io/api/v1/exports'
 
 params = {
     name: "My export name (1)",
@@ -357,7 +357,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/exports/create"
+url = "https://scrap.io/api/v1/exports"
  
 params = {
   "name": "My export name (1)",
@@ -383,7 +383,7 @@ json = response.json()
 ```
 
 ```shell
-curl --location --request POST 'https://scrap-io.test/api/v1/exports/create' \
+curl --location --request POST 'https://scrap-io.test/api/v1/exports' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer xxxxxxxxxxx'
 --data '{
@@ -404,7 +404,7 @@ curl --location --request POST 'https://scrap-io.test/api/v1/exports/create' \
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/exports/create'
+const url = 'https://scrap.io/api/v1/exports'
 
 const params = {
     name: "My export name (1)",
@@ -465,7 +465,7 @@ axios.post(url, params, headers)
 
 ### HTTP Request
 
-`POST https://scrap.io/api/v1/exports/create`
+`POST https://scrap.io/api/v1/exports`
 
 ### Body parameters
 
@@ -481,7 +481,7 @@ axios.post(url, params, headers)
 | exported_lines_limit | integer | no |  | The maximum number of results wanted in the export. |
 | export_only_new_place | boolean | no |  | Export only places not present in previous exports. |
 | export_only_new_email | boolean | no |  | Export only places with email not already present in previous exports. |
-| export_columns | array | yes | See "Export columns" section below | Columns to include in the export file. Require at least one column. |
+| exported_columns | array | yes | See "Export columns" section below | Columns to include in the export file. Require at least one column. |
 | gmap_is_main_type | boolean | no | | Filter by main business type only |
 | gmap_is_closed | boolean | no | | Filter by permanently closed status |
 | gmap_has_website | boolean | no | | Filter by presence of website |
@@ -778,106 +778,3 @@ This endpoint allows you to delete one of your exports.
 ### HTTP Request
 
 `DELETE https://scrap.io/api/v1/exports/{id}`
-
-
-## Bulk delete
-
-```php
-$url = 'https://scrap.io/api/v1/exports/bulk-delete';
-
-$params = [
-    "export_ids" => [1, 2]
-];
-
-$headers = [
-  'Authorization: Bearer xxxxxxxxxx'
-];
-
-$curl = curl_init();
-curl_setopt($curl, CURLOPT_URL, $url);
-curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
-curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-
-$json = json_decode($response);
-```
-
-```ruby
-require 'httparty'
-require 'json'
-
-url = 'https://scrap.io/api/v1/exports/bulk-delete'
-
-params = {
-    export_ids: [1, 2]
-}
-
-headers = {
-  Authorization: 'Bearer xxxxxxxxxx',
-}
-
-response = HTTParty.post(url, headers: headers, body: params)
-
-json = JSON.parse(response.body)
-```
-
-```python
-import requests
-import json
- 
-url = "https://scrap.io/api/v1/exports/bulk-delete"
- 
-params = {
-  "export_ids": [1, 2]
-}
- 
-headers = {
-  "Authorization": "Bearer xxxxxxxxxx"
-}
-
-response = requests.post(url, data=params, headers=headers)
- 
-json = response.json()
-```
-
-```shell
-curl --location --request POST 'https://scrap-io.test/api/v1/exports/bulk-delete' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer xxxxxxxxxxx'
---data '{
-    "export_ids": [1, 2]
-}'
-```
-
-```javascript
-const axios = require('axios')
-
-const url = 'https://scrap.io/api/v1/exports/bulk-delete'
-
-const params = {
-    export_ids: [1, 2]
-}
-
- axios.post(url, { data: params, headers: { Authorization: 'Bearer xxxxxxxxxx' } })
-  .then((response) => {
-    json = JSON.parse(response.data)  
-  });
-```
-
-> The above code returns a 202 status code (accepted).
-
-This endpoint allows you to delete one or multiple of your exports.
-
-### HTTP Request
-
-`POST https://scrap.io/api/v1/exports/bulk-delete`
-
-### Body parameters
-
-| Parameter  | Type  | Required | Description                    |
-|------------|-------|----------|--------------------------------|
-| export_ids | array | yes      | A list of export ids to delete |

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -81,6 +81,14 @@ axios.get(url, headers)
 
 ```json
 {
+    "meta": {
+        "count": 2,
+        "current_page": 1,
+        "previous_page": null,
+        "next_page": null,
+        "per_page": 25,
+        "has_more_pages": false
+    },
     "data": [
         {
             "id": 1,
@@ -140,38 +148,6 @@ axios.get(url, headers)
             "download_link": "https://scrap.io/app/export/d22e9717f0185d70848d2f7b75b1ced8a339ee4d4be92697f0cb5c4b6911a5f5/download/csv"
         },
     ],
-    "links": {
-        "first": "https://scrap.io/api/v1/exports?page=1",
-        "last": "https://scrap.io/api/v1/exports?page=1",
-        "prev": null,
-        "next": null
-    },
-    "meta": {
-        "current_page": 1,
-        "from": 1,
-        "last_page": 1,
-        "links": [
-            {
-                "url": null,
-                "label": "&laquo; Previous",
-                "active": false
-            },
-            {
-                "url": "https://scrap.io/api/v1/exports?page=1",
-                "label": "1",
-                "active": true
-            },
-            {
-                "url": null,
-                "label": "Next &raquo;",
-                "active": false
-            }
-        ],
-        "path": "https://scrap.io/api/v1/exports",
-        "per_page": 25,
-        "to": 2,
-        "total": 2
-    }
 }
 ```
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -697,7 +697,7 @@ This endpoint allows you to rename one of your exports.
 ## Bulk delete
 
 ```php
-$url = 'https://scrap.io/api/v1/exports';
+$url = 'https://scrap.io/api/v1/exports/bulk-delete';
 
 $params = [
     "export_ids" => [1, 2]
@@ -709,7 +709,6 @@ $headers = [
 
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_URL, $url);
-curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
 curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
 curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -725,7 +724,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/exports'
+url = 'https://scrap.io/api/v1/exports/bulk-delete'
 
 params = {
     export_ids: [1, 2]
@@ -735,7 +734,7 @@ headers = {
   Authorization: 'Bearer xxxxxxxxxx',
 }
 
-response = HTTParty.delete(url, headers: headers, body: params)
+response = HTTParty.post(url, headers: headers, body: params)
 
 json = JSON.parse(response.body)
 ```
@@ -744,7 +743,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/exports"
+url = "https://scrap.io/api/v1/exports/bulk-delete"
  
 params = {
   "export_ids": [1, 2]
@@ -754,13 +753,13 @@ headers = {
   "Authorization": "Bearer xxxxxxxxxx"
 }
 
-response = requests.delete(url, data=params, headers=headers)
+response = requests.post(url, data=params, headers=headers)
  
 json = response.json()
 ```
 
 ```shell
-curl --location --request DELETE 'https://scrap-io.test/api/v1/exports' \
+curl --location --request POST 'https://scrap-io.test/api/v1/exports/bulk-delete' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer xxxxxxxxxxx'
 --data '{
@@ -771,13 +770,13 @@ curl --location --request DELETE 'https://scrap-io.test/api/v1/exports' \
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/exports'
+const url = 'https://scrap.io/api/v1/exports/bulk-delete'
 
 const params = {
     export_ids: [1, 2]
 }
 
- axios.delete(url, { data: params, headers: { Authorization: 'Bearer xxxxxxxxxx' } })
+ axios.post(url, { data: params, headers: { Authorization: 'Bearer xxxxxxxxxx' } })
   .then((response) => {
     json = JSON.parse(response.data)  
   });
@@ -789,7 +788,7 @@ This endpoint allows you to delete one or multiple of your exports.
 
 ### HTTP Request
 
-`DELETE https://scrap.io/api/v1/exports`
+`POST https://scrap.io/api/v1/exports/bulk-delete`
 
 ### Body parameters
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -481,7 +481,7 @@ axios.post(url, params, headers)
 | exported_lines_limit | integer | no |  | The maximum number of results wanted in the export. |
 | export_only_new_place | boolean | no |  | Export only places not present in previous exports. |
 | export_only_new_email | boolean | no |  | Export only places with email not already present in previous exports. |
-| exported_columns | array | yes | See "Export columns" section below | Columns to include in the export file. Require at least one column. |
+| exported_columns | array | no | See "Export columns" section below. | Columns to include in the export file. Require at least one column if passed. If no specified, all columns will be exported. |
 | gmap_is_main_type | boolean | no | | Filter by main business type only |
 | gmap_is_closed | boolean | no | | Filter by permanently closed status |
 | gmap_has_website | boolean | no | | Filter by presence of website |
@@ -771,7 +771,13 @@ axios.delete(url, headers)
   });
 ```
 
-> The above code returns a 200 status code (OK).
+> The above code returns JSON structured like this:
+
+```json
+{
+    "message": "success"
+}
+```
 
 This endpoint allows you to delete one of your exports.
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -693,6 +693,92 @@ This endpoint allows you to rename one of your exports.
 |-----------|--------|----------|---------------------------------------------|
 | name      | string | yes      | The name of the export. Must be unique, min 3 char and max 255 char. |
 
+## Delete (one)
+
+<!--  PHP code -->
+```php
+$url = 'https://scrap.io/api/v1/exports/2';
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+<!--  RUBY code -->
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports/2'
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.delete(url, headers: headers)
+
+json = JSON.parse(response.body)
+```
+
+<!--  PYTHON code -->
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports/2"
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.delete(url, headers=headers)
+ 
+json = response.json()
+```
+
+<!--  SHELL code -->
+```shell
+curl --location --request DELETE 'https://scrap-io.test/api/v1/exports/2' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx'
+```
+
+<!--  JS code -->
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports/2'
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.delete(url, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns a 200 status code (OK).
+
+This endpoint allows you to delete one of your exports.
+
+### HTTP Request
+
+`DELETE https://scrap.io/api/v1/exports/{id}`
+
 
 ## Bulk delete
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -167,7 +167,7 @@ This endpoint allows you to get a paginated list of your exports.
 |-----------|---------------|---------|----------|---------------------------------------------------|------------------------|
 | search    | string        |         | no       |                                                   | Search in export name  |
 | status    | string/array  |         | no       | in_progress, pending, incomplete, success, error  | Status of the export   |
-| orderBy   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
+| order_by   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
 | page      | integer       | 1       | no       |                                                   | Get the results for the given page |
 
 
@@ -777,11 +777,7 @@ const params = {
     export_ids: [1, 2]
 }
 
-const headers = {
-  headers: { Authorization: 'Bearer xxxxxxxxxx' },
-}
-
-axios.delete(url, params, headers)
+ axios.delete(url, { data: params, headers: { Authorization: 'Bearer xxxxxxxxxx' } })
   .then((response) => {
     json = JSON.parse(response.data)  
   });

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -166,7 +166,7 @@ This endpoint allows you to get a paginated list of your exports.
 | Parameter | Type          | Default | Required | Options                                           | Description            |
 |-----------|---------------|---------|----------|---------------------------------------------------|------------------------|
 | search    | string        |         | no       |                                                   | Search in export name  |
-| status    | string/array  |         | no       | in_progress, pending, incomplete, success, error  | Status of the export   |
+| status    | array  |         | no       | preparing-scraping, scraping, preparing-export, exporting-csv, exporting-xlsx, pending, incomplete, success, error  | Status of the export   |
 | order_by   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
 | page      | integer       | 1       | no       |                                                   | Get the results for the given page |
 

--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -56,8 +56,9 @@ json = response.json()
 
 <!--  SHELL code -->
 ```shell
-curl 'https://scrap.io/api/v1/export?status=success&order_by=asc' \
-    -H "Authorization: Bearer xxxxxxxxxxx"
+curl --location --request GET 'https://scrap-io.test/api/v1/exports' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx \'
 ```
 
 <!--  JS code -->
@@ -186,12 +187,12 @@ This endpoint allows you to get a paginated list of your exports.
 
 ### Query parameters
 
-| Parameter | Type          | Default | Required | Description            | Options                                           |
-|-----------|---------------|---------|----------|------------------------|---------------------------------------------------|
-| search    | string        |         | no       | Search in export name  |                                                   |
-| status    | string/array  |         | no       | Status of the export   | in_progress, pending, incomplete, success, error  |
-| orderBy   | string        | desc    | no       | Sort by scraping_date  | asc, desc                                         |
-| page      | integer       | 1       | no       | Get the results for the given page |                                       |
+| Parameter | Type          | Default | Required | Options                                           | Description            |
+|-----------|---------------|---------|----------|---------------------------------------------------|------------------------|
+| search    | string        |         | no       |                                                   | Search in export name  |
+| status    | string/array  |         | no       | in_progress, pending, incomplete, success, error  | Status of the export   |
+| orderBy   | string        | desc    | no       | asc, desc                                         | Sort by scraping_date  |
+| page      | integer       | 1       | no       |                                                   | Get the results for the given page |                                     |
 
 
 ## Find
@@ -250,8 +251,9 @@ json = response.json()
 
 <!--  SHELL code -->
 ```shell
-curl 'https://scrap.io/api/v1/export/2' \
-    -H "Authorization: Bearer xxxxxxxxxxx"
+curl --location --request GET 'https://scrap-io.test/api/v1/exports/2' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx \'
 ```
 
 <!--  JS code -->
@@ -307,7 +309,7 @@ This endpoint allows you to get one of your exports depending on the id.
 
 ### HTTP Request
 
-`GET https://scrap.io/api/v1/exports/create`
+`GET https://scrap.io/api/v1/exports/{id}`
 
 ## Create
 
@@ -405,22 +407,22 @@ json = response.json()
 ```
 
 ```shell
-curl -X POST "https://scrap.io/api/v1/exports/create" \
-  -H "Authorization: Bearer xxxxxxxxxx" \
-  -d "type=domain" \
-  -d '{
-        "name": "My export name (1)",
-        "country_code": "FR",
-        "type": "karaoke-bar",
-        "admin1_code": "75",
-        "exported_lines_limit": 4,
-        "exported_columns": [
-            "google_id", 
-            "name"
-        ],
-        "gmap_price_range": "$$",
-        "website_has_instagram": true
-    }'
+curl --location --request POST 'https://scrap-io.test/api/v1/exports/create' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx \'
+--data '{
+    "name": "My export name (1)",
+    "country_code": "FR",
+    "type": "karaoke-bar",
+    "admin1_code": "75",
+    "exported_lines_limit": 4,
+    "exported_columns": [
+        "google_id", 
+        "name"
+    ],
+    "gmap_price_range": "$$",
+    "website_has_instagram": true
+}'
 ```
 
 ```javascript
@@ -450,26 +452,6 @@ axios.post(url, params, headers)
   .then((response) => {
     json = JSON.parse(response.data)  
   });
-```
-
-
-```shell
-curl --location 'https://scrap-io.test/api/v1/exports/create' \
---header 'Content-Type: application/json' \
---header 'Authorization: xxxxxxxxxxx' \
---data '{
-    "name": "My export name (1)",
-    "country_code": "FR",
-    "type": "karaoke-bar",
-    "admin1_code": "75",
-    "exported_lines_limit": 4,
-    "exported_columns": [
-        "google_id", 
-        "name"
-    ],
-    "gmap_price_range": "$$",
-    "website_has_instagram": true
-}'
 ```
 
 > The above code returns JSON structured like this:
@@ -511,13 +493,6 @@ curl --location 'https://scrap-io.test/api/v1/exports/create' \
 
 ### Body parameters
 
-**Important informations**
-
-- Unless otherwise specified, a non-required field will be null by default (even if not passed in parameters).
-- Filters are ignore if not present or null. For example, if website_has_instagram set to true, we'll return results WITH instagram links, if set to false we'll return results WITHOUT instagram links and if not present at all we'll return results WITH or WITHOUT instagram links.
-
-**Parameters**
-
 | Parameter | Type | Required | Options | Description |
 |---|---|---|---|---|
 | name | string | yes if auto_name not present or false |  | The name of the export. Must be unique, min 3 char and max 255 char. |
@@ -526,7 +501,7 @@ curl --location 'https://scrap-io.test/api/v1/exports/create' \
 | country_code | string | yes | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Country. |
 | admin1_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 1 division for the country. |
 | admin2_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 2 division for the country. |
-| city_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | City. |
+| city | string | no | Text from this [endpoint](https://apidoc.scrap.io/#locations) | City. |
 | exported_lines_limit | integer | no |  | The maximum number of results wanted in the export. |
 | export_only_new_place | boolean | no |  | Export only places not present in previous exports. |
 | export_only_new_email | boolean | no |  | Export only places with email not already present in previous exports. |
@@ -603,3 +578,249 @@ curl --location 'https://scrap-io.test/api/v1/exports/create' \
 | all_linkedin_links | All linkedin links |
 | website_technologies | Website technologies |
 | website_ad_pixels | Website pixel ad |
+
+## Update
+
+```php
+$url = 'https://scrap.io/api/v1/exports/3';
+
+$params = [
+    "name" => "My new export name"
+];
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PATCH');
+curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports/3'
+
+params = {
+    name: "My new export name",
+}
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.patch(url, headers: headers, body: params)
+
+json = JSON.parse(response.body)
+```
+
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports/3"
+ 
+params = {
+  "name": "My new export name",
+}
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.patch(url, data=params, headers=headers)
+ 
+json = response.json()
+```
+
+```shell
+curl --location --request PATCH 'https://scrap-io.test/api/v1/exports/3' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx \'
+--data '{
+    "name": "My new export name",
+}'
+```
+
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports/3'
+
+const params = {
+    name: "My new export name",
+}
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.patch(url, params, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns JSON structured like this:
+
+```json
+{
+    "id": 3,
+    "name": "My new export name",
+    "country": "FR",
+    "type": "karaoke-bar",
+    "search_params": {
+        "type": "karaoke-bar",
+        "country": "FR",
+        "admin1": "75"
+    },
+    "status": "pending",
+    "advanced_fields": [],
+    "exported_lines_limit": null,
+    "exported_columns": [
+        "google_id",
+        "name"
+    ],
+    "prepared_rows_count": 10,
+    "exported_csv_count": 10,
+    "exported_xlsx_count": 10,
+    "is_stopped": false,
+    "has_been_downloaded": false,
+    "credits_used": 0,
+    "export_only_new_email": 0,
+    "export_only_new_place": 0,
+    "scraped_at": "2025-02-19T07:04:09.000000Z",
+    "download_link": ""
+}
+```
+
+This endpoint allows you to rename one of your exports.
+
+### HTTP Request
+
+`PATCH https://scrap.io/api/v1/exports/{id}`
+
+### Body parameters
+
+| Parameter | Type   | Required | Description                                 |
+|-----------|--------|----------|---------------------------------------------|
+| name      | string | yes      | The name of the export. Must be unique, min 3 char and max 255 char. |
+
+
+## Bulk delete
+
+```php
+$url = 'https://scrap.io/api/v1/exports';
+
+$params = [
+    "export_ids" => [1, 2]
+];
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/exports'
+
+params = {
+    export_ids: [1, 2]
+}
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.delete(url, headers: headers, body: params)
+
+json = JSON.parse(response.body)
+```
+
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/exports"
+ 
+params = {
+  "export_ids": [1, 2]
+}
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.delete(url, data=params, headers=headers)
+ 
+json = response.json()
+```
+
+```shell
+curl --location --request DELETE 'https://scrap-io.test/api/v1/export' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer xxxxxxxxxxx \'
+--data '{
+    "ids": [1, 2]
+}'
+```
+
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/exports'
+
+const params = {
+    export_ids: [1, 2]
+}
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.delete(url, params, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns a 202 status code (accepted).
+
+This endpoint allows you to delete one or multiple of your exports.
+
+### HTTP Request
+
+`DELETE https://scrap.io/api/v1/export`
+
+### Body parameters
+
+| Parameter  | Type  | Required | Description                    |
+|------------|-------|----------|--------------------------------|
+| export_ids | array | yes      | A list of export ids to delete |

--- a/source/includes/_gmap.md
+++ b/source/includes/_gmap.md
@@ -1193,7 +1193,7 @@ We also provide powerful filters that allow you to fine-tune the search accordin
 | country_code |  | yes | ISO Country code (FR, US, etc.) |
 | admin1_code |  | no | ID of admin1 location to search for |
 | admin2_code |  | no | ID of admin2 location to search for |
-| city |  | no | ID of city to search for |
+| city |  | no | Name of city to search for |
 | postal_code |  | no | Postal code to search for |
 | gmap_is_main_type |  | no | Boolean (0 = false / 1 = true) |
 | gmap_is_closed |  | no | Boolean (0 = false / 1 = true) |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -22,6 +22,7 @@ includes:
   - subscription
   - gmap
   - blacklist
+  - export
   - errors
 
 search: true


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced comprehensive API documentation for Scrap.io service, detailing export management endpoints with multi-language code examples.
	- Clarified that the city search parameter now requires the city name instead of an ID.
	- Updated the `data` parameter definition across multiple programming languages to consistently require an array format.
	- Expanded the overall documentation content to include new export-related information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->