### PR TITLE
SCP-145 (feature) api get elements inside a blacklist

### DIFF
--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -100,6 +100,130 @@ This endpoint allows you to get the list of all your blacklists.
 
 `GET https://scrap.io/api/v1/blacklist`
 
+## Show
+
+```php
+$url = 'https://scrap.io/api/v1/blacklist/my-list';
+
+$headers = [
+  'Authorization: Bearer xxxxxxxxxx'
+];
+
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+
+$json = json_decode($response);
+```
+
+```ruby
+require 'httparty'
+require 'json'
+
+url = 'https://scrap.io/api/v1/blacklist/my-list'
+
+headers = {
+  Authorization: 'Bearer xxxxxxxxxx',
+}
+
+response = HTTParty.get(url, headers: headers)
+
+json = JSON.parse(response.body)
+```
+
+```python
+import requests
+import json
+ 
+url = "https://scrap.io/api/v1/blacklist/my-list"
+ 
+headers = {
+  "Authorization": "Bearer xxxxxxxxxx"
+}
+
+response = requests.get(url, headers=headers)
+ 
+json = response.json()
+```
+
+```shell
+curl "https://scrap.io/api/v1/blacklist/my-list" \
+  -H "Authorization: Bearer xxxxxxxxxx"
+```
+
+```javascript
+const axios = require('axios')
+
+const url = 'https://scrap.io/api/v1/blacklist/my-list'
+
+const headers = {
+  headers: { Authorization: 'Bearer xxxxxxxxxx' },
+}
+
+axios.get(url, headers)
+  .then((response) => {
+    json = JSON.parse(response.data)  
+  });
+```
+
+> The above code returns JSON structured like this:
+
+```json
+{
+    "current_page": 1,
+    "data": [
+        {
+            "list": "my-list",
+            "type": "email",
+            "data": "myEmail@test.com"
+        },
+        {
+            "list": "my-list",
+            "type": "email",
+            "data": "myEmail2@test.com"
+        },
+    ],
+    "first_page_url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
+    "from": 1,
+    "last_page": 1,
+    "last_page_url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
+    "links": [
+        {
+            "url": null,
+            "label": "&laquo; Previous",
+            "active": false
+        },
+        {
+            "url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
+            "label": "1",
+            "active": true
+        },
+        {
+            "url": null,
+            "label": "Next &raquo;",
+            "active": false
+        }
+    ],
+    "next_page_url": null,
+    "path": "https://scrap.io/api/v1/blacklist/my-list",
+    "per_page": 50,
+    "prev_page_url": null,
+    "to": 3,
+    "total": 3
+}
+```
+
+This endpoint allows you to get a paginated list of all your entries for a specific blackist.
+
+**HTTP Request**
+
+`GET https://scrap.io/api/v1/blacklist/{list-name}`
+
 ## Add
 
 ```php

--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -175,7 +175,14 @@ axios.get(url, headers)
 
 ```json
 {
-    "current_page": 1,
+    "meta": {
+        "count": 2,
+        "current_page": 1,
+        "previous_page": null,
+        "next_page": null,
+        "per_page": 50,
+        "has_more_pages": false
+    },
     "data": [
         {
             "list": "my-list",
@@ -188,33 +195,6 @@ axios.get(url, headers)
             "data": "myEmail2@test.com"
         },
     ],
-    "first_page_url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
-    "from": 1,
-    "last_page": 1,
-    "last_page_url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
-    "links": [
-        {
-            "url": null,
-            "label": "&laquo; Previous",
-            "active": false
-        },
-        {
-            "url": "https://scrap.io/api/v1/blacklist/my-list?page=1",
-            "label": "1",
-            "active": true
-        },
-        {
-            "url": null,
-            "label": "Next &raquo;",
-            "active": false
-        }
-    ],
-    "next_page_url": null,
-    "path": "https://scrap.io/api/v1/blacklist/my-list",
-    "per_page": 50,
-    "prev_page_url": null,
-    "to": 3,
-    "total": 3
 }
 ```
 

--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -224,6 +224,12 @@ This endpoint allows you to get a paginated list of all your entries for a speci
 
 `GET https://scrap.io/api/v1/blacklist/{list-name}`
 
+### Query parameters
+
+| Parameter | Type          | Default | Required | Options                                           | Description            |
+|-----------|---------------|---------|----------|---------------------------------------------------|------------------------|
+| page      | integer       | 1       | no       |                                                   | Get the results for the given page |
+
 ## Add
 
 ```php


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the blacklist API documentation with a new "Show" section.
  - Added practical code examples in PHP, Ruby, Python, Shell, and JavaScript demonstrating how to retrieve specific blacklist details.
  - Detailed the expected JSON response structure, including pagination information for enhanced clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->