### PR TITLE
SCP-158 (feature) remove banner from api doc

### DIFF
--- a/source/includes/_export.md
+++ b/source/includes/_export.md
@@ -153,10 +153,6 @@ axios.get(url, headers)
 
 This endpoint allows you to get a paginated list of your exports.
 
-<aside class="warning">
-  We won't return deleted exports.
-</aside>
-
 ### HTTP Request
 
 `GET https://scrap.io/api/v1/exports`
@@ -474,7 +470,7 @@ axios.post(url, params, headers)
 | name | string | yes if auto_name not present or false |  | The name of the export. Must be unique, min 3 char and max 255 char |
 | auto_name | boolean | yes if name not present | 0 = false / 1 = true | If set, we'll generate a name for you |
 | type | string | yes | Id from this [endpoint](https://apidoc.scrap.io/#types) | Type of place |
-| country_code | string | yes |  | ISO Country code (FR, US, etc.) |
+| country_code | string | yes |  | 2 letters (ISO 3166-1 alpha-2) country code (FR, US, etc.) |
 | admin1_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 1 division for the country |
 | admin2_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 2 division for the country |
 | city | string | no | Text from this [endpoint](https://apidoc.scrap.io/#locations) | City |

--- a/source/includes/_gmap.md
+++ b/source/includes/_gmap.md
@@ -263,7 +263,7 @@ Then, you can use the ID in the gmap search endpoint.
 
 Parameter | Default | Required | Description
 --------- | ------- | ------- | -----------
-country_code | | yes | ISO Country code (FR,US, etc.)
+country_code | | yes | 2 letters (ISO 3166-1 alpha-2) country code (FR, US, etc.)
 type | | yes |  Type of entity to search for (admin1, admin2, city)
 admin1_code | | no | Admin 1 code (if you want to restrict to a specific admin 1 division)
 admin2_code | | no | Admin 2 code (if you want to restrict to a specific admin 2 division)
@@ -1194,7 +1194,7 @@ We also provide powerful filters that allow you to fine-tune the search accordin
 | blacklists | array | no | | Array containing blacklist names. When specify, only the given blacklists will be verify. Default: Verify all blacklists |
 | cursor | string | no | | Cursor pagination |
 | type | string | yes | | ID of Gmap type to search for |
-| country_code | string | yes |  | ISO Country code (FR, US, etc.) |
+| country_code | string | yes |  | 2 letters (ISO 3166-1 alpha-2) country code (FR, US, etc.) |
 | admin1_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 1 division for the country |
 | admin2_code | string | no | Id from this [endpoint](https://apidoc.scrap.io/#locations) | Level 2 division for the country |
 | city | string | no | Text from this [endpoint](https://apidoc.scrap.io/#locations) | City |


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed a warning message regarding deleted exports.
  - Updated API documentation to clarify that the country code should be a 2-letter ISO 3166-1 alpha-2 code, ensuring better clarity for users across all relevant endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->