### PR TITLE
SCP-172 (feature) display timeout error check api

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -5,11 +5,13 @@ The Scrap.io API uses the following error codes:
 
 Error Code | Meaning
 ---------- | -------
-401 | Unauthorized -- Your API key is wrong, or not authorized to access this endpoint.
-404 | Not Found -- The resource was not be found.
+401 | Unauthenticated -- Your API key is wrong, or not authorized to access this endpoint.
+403 | Unauthorized -- You don't have the authorization to execute this request.
+404 | Not Found -- The resource was not found.
 405 | Method Not Allowed -- You tried to access an endpoint with an invalid method.
+408 | Timeout -- Too many results to process. Please, try refining your search.
 422 | Unprocessable entity -- Your request is invalid.
 423 | Locked -- The resource cannot be accessed.
-429 | Too Many Requests -- You're making too many resquests! Slow down!
+429 | Too Many Requests -- You're making too many requests! Slow down!
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 503 | Service Unavailable -- We're temporarily offline for maintenance. Please try again later.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified error code descriptions, distinguishing between authentication (401 Unauthenticated) and authorization (403 Unauthorized) errors.
	- Corrected typos in 404 ("was not found") and 429 ("requests") error messages.
	- Added a new 408 error code for timeouts, with guidance to refine searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->