### PR TITLE
SCP-155 (feature) harmonize blacklist api endpoints

### DIFF
--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -4,14 +4,18 @@ Our API includes a feature that allows you to add items to a blacklist by **emai
 
 This feature is particularly useful to avoid re-scraping the same results, and counting your credits again for the same data.
 
-<aside class="warning">
+<aside class="info">
   You can blacklist up to 10 million items.
+</aside>
+
+<aside class="warning">
+  We've changed our endpoints! Don't worry, old endpoints are still available for now but don't forget to update them.
 </aside>
 
 ## List
 
 ```php
-$url = 'https://scrap.io/api/v1/blacklist';
+$url = 'https://scrap.io/api/v1/blacklists';
 
 $headers = [
   'Authorization: Bearer xxxxxxxxxx'
@@ -33,7 +37,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/blacklist'
+url = 'https://scrap.io/api/v1/blacklists'
 
 headers = {
   Authorization: 'Bearer xxxxxxxxxx',
@@ -48,7 +52,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/blacklist"
+url = "https://scrap.io/api/v1/blacklists"
  
 headers = {
   "Authorization": "Bearer xxxxxxxxxx"
@@ -60,14 +64,14 @@ json = response.json()
 ```
 
 ```shell
-curl "https://scrap.io/api/v1/blacklist" \
+curl "https://scrap.io/api/v1/blacklists" \
   -H "Authorization: Bearer xxxxxxxxxx"
 ```
 
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/blacklist'
+const url = 'https://scrap.io/api/v1/blacklists'
 
 const headers = {
   headers: { Authorization: 'Bearer xxxxxxxxxx' },
@@ -98,12 +102,12 @@ This endpoint allows you to get the list of all your blacklists.
 
 **HTTP Request**
 
-`GET https://scrap.io/api/v1/blacklist`
+`GET https://scrap.io/api/v1/blacklists`
 
 ## Show
 
 ```php
-$url = 'https://scrap.io/api/v1/blacklist/my-list';
+$url = 'https://scrap.io/api/v1/blacklists/my-list';
 
 $headers = [
   'Authorization: Bearer xxxxxxxxxx'
@@ -125,7 +129,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/blacklist/my-list'
+url = 'https://scrap.io/api/v1/blacklists/my-list'
 
 headers = {
   Authorization: 'Bearer xxxxxxxxxx',
@@ -140,7 +144,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/blacklist/my-list"
+url = "https://scrap.io/api/v1/blacklists/my-list"
  
 headers = {
   "Authorization": "Bearer xxxxxxxxxx"
@@ -152,14 +156,14 @@ json = response.json()
 ```
 
 ```shell
-curl "https://scrap.io/api/v1/blacklist/my-list" \
+curl "https://scrap.io/api/v1/blacklists/my-list" \
   -H "Authorization: Bearer xxxxxxxxxx"
 ```
 
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/blacklist/my-list'
+const url = 'https://scrap.io/api/v1/blacklists/my-list'
 
 const headers = {
   headers: { Authorization: 'Bearer xxxxxxxxxx' },
@@ -202,7 +206,7 @@ This endpoint allows you to get a paginated list of all your entries for a speci
 
 **HTTP Request**
 
-`GET https://scrap.io/api/v1/blacklist/{list-name}`
+`GET https://scrap.io/api/v1/blacklists/{list-name}`
 
 ### Query parameters
 
@@ -213,7 +217,7 @@ This endpoint allows you to get a paginated list of all your entries for a speci
 ## Add
 
 ```php
-$url = 'https://scrap.io/api/v1/blacklist/my-list-1';
+$url = 'https://scrap.io/api/v1/blacklists/my-list-1';
 
 $params = [
   'type' => 'domain',
@@ -242,7 +246,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/blacklist/my-list-1'
+url = 'https://scrap.io/api/v1/blacklists/my-list-1'
 
 params = {
   type: 'domain',
@@ -262,7 +266,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/blacklist/my-list-1"
+url = "https://scrap.io/api/v1/blacklists/my-list-1"
  
 params = {
   "type": "domain",
@@ -279,7 +283,7 @@ json = response.json()
 ```
 
 ```shell
-curl -X POST "https://scrap.io/api/v1/blacklist/my-list-1" \
+curl -X POST "https://scrap.io/api/v1/blacklists/my-list-1" \
   -H "Authorization: Bearer xxxxxxxxxx" \
   -d "type=domain" \
   -d "data=['sugarfishsushi.com']"
@@ -288,7 +292,7 @@ curl -X POST "https://scrap.io/api/v1/blacklist/my-list-1" \
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/blacklist/my-list-1'
+const url = 'https://scrap.io/api/v1/blacklists/my-list-1'
 
 const params = {
   type: 'domain',
@@ -317,7 +321,7 @@ This endpoint allows you to add data to a blacklist (google_id, place_id, domain
 
 **HTTP Request**
 
-`POST https://scrap.io/api/v1/blacklist/{list-name}`
+`POST https://scrap.io/api/v1/blacklists/{list-name}`
 
 ### Query Parameters
 
@@ -329,7 +333,7 @@ data | array | yes | Data to add to the blacklist. Must be an array of strings [
 ## Delete
 
 ```php
-$url = 'https://scrap.io/api/v1/blacklist/my-list-1';
+$url = 'https://scrap.io/api/v1/blacklists/my-list-1';
 
 $headers = [
   'Authorization: Bearer xxxxxxxxxx'
@@ -352,7 +356,7 @@ $json = json_decode($response);
 require 'httparty'
 require 'json'
 
-url = 'https://scrap.io/api/v1/blacklist/my-list-1'
+url = 'https://scrap.io/api/v1/blacklists/my-list-1'
 
 headers = {
   Authorization: 'Bearer xxxxxxxxxx',
@@ -367,7 +371,7 @@ json = JSON.parse(response.body)
 import requests
 import json
  
-url = "https://scrap.io/api/v1/blacklist/my-list-1"
+url = "https://scrap.io/api/v1/blacklists/my-list-1"
  
 headers = {
   "Authorization": "Bearer xxxxxxxxxx"
@@ -379,14 +383,14 @@ json = response.json()
 ```
 
 ```shell
-curl -X DELETE "https://scrap.io/api/v1/blacklist/my-list-1" \
+curl -X DELETE "https://scrap.io/api/v1/blacklists/my-list-1" \
   -H "Authorization: Bearer xxxxxxxxxx"
 ```
 
 ```javascript
 const axios = require('axios')
 
-const url = 'https://scrap.io/api/v1/blacklist/my-list-1'
+const url = 'https://scrap.io/api/v1/blacklists/my-list-1'
 
 const headers = {
   headers: { Authorization: 'Bearer xxxxxxxxxx' },
@@ -410,4 +414,4 @@ This endpoint allows you to delete a list.
 
 **HTTP Request**
 
-`DELETE https://scrap.io/api/v1/blacklist/{list-name}`
+`DELETE https://scrap.io/api/v1/blacklists/{list-name}`

--- a/source/includes/_blacklist.md
+++ b/source/includes/_blacklist.md
@@ -4,12 +4,8 @@ Our API includes a feature that allows you to add items to a blacklist by **emai
 
 This feature is particularly useful to avoid re-scraping the same results, and counting your credits again for the same data.
 
-<aside class="info">
-  You can blacklist up to 10 million items.
-</aside>
-
 <aside class="warning">
-  We've changed our endpoints! Don't worry, old endpoints are still available for now but don't forget to update them.
+  You can blacklist up to 10 million items.
 </aside>
 
 ## List

--- a/source/includes/_gmap.md
+++ b/source/includes/_gmap.md
@@ -1,5 +1,9 @@
 # GMap
 
+<aside class="warning">
+  We've changed our endpoints! Don't worry, old endpoints are still available for now but don't forget to update them.
+</aside>
+
 ## Types
 
 ```php

--- a/source/includes/_gmap.md
+++ b/source/includes/_gmap.md
@@ -1,9 +1,5 @@
 # GMap
 
-<aside class="warning">
-  We've changed our endpoints! Don't worry, old endpoints are still available for now but don't forget to update them.
-</aside>
-
 ## Types
 
 ```php


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated all API documentation and code examples to use `/blacklists` instead of `/blacklist` in endpoint URLs across all relevant operations and programming languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->